### PR TITLE
Module::Signature is not really required by the tests

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,7 +24,7 @@ my %WriteMakefileArgs = (
     "strict" => 0
   },
   "TEST_REQUIRES" => {
-    "Module::Signature" => 0,
+    # "Module::Signature" => 0,
     "Socket" => 0,
     "Test::More" => 0
   },


### PR DESCRIPTION
and it makes it harder to install the module
