### PR TITLE
Add tests for override flag (PRC)

### DIFF
--- a/t/smoke.t
+++ b/t/smoke.t
@@ -24,14 +24,12 @@ is $val, undef, "$key is no longer set in C env";
 my $val_new = "foobar";
 Env::C::setenv($key, $val_new);
 $val = Env::C::getenv($key) || '';
-print "# [$key] expecting '$val_new', got '$val'\n";
-ok $val eq $val_new ? 1 : 0;
+is $val, $val_new, "reinstated $key in C env";
 
 # restore
 Env::C::setenv($key, $val_orig);
 $val = Env::C::getenv($key) || '';
-print "# [$key] expecting '$val_orig', got '$val'\n";
-ok $val eq $val_orig ? 1 : 0;
+is $val, $val_orig, "restored $key (using setenv with implicit override)";
 
 my $env = Env::C::getallenv();
 print "# ", scalar(@$env), " env entries\n";

--- a/t/smoke.t
+++ b/t/smoke.t
@@ -1,7 +1,7 @@
 use strict;
 #use warnings;
 
-use Test::More tests => 7;
+use Test::More tests => 9;
 use Env::C;
 
 # we assume $ENV{USER} exists, but that might not be the case (e.g.: in
@@ -25,6 +25,15 @@ my $val_new = "foobar";
 Env::C::setenv($key, $val_new);
 $val = Env::C::getenv($key) || '';
 is $val, $val_new, "reinstated $key in C env";
+
+my $overwrite = "barbaz";
+Env::C::setenv($key, $overwrite, 0);
+$val = Env::C::getenv($key) || '';
+is $val, $val_new, "do not overwrite $key with explicitly false override";
+
+Env::C::setenv($key, $val_new, 1);
+$val = Env::C::getenv($key) || '';
+is $val, $val_new, "overwrite $key with explicitly true override";
 
 # restore
 Env::C::setenv($key, $val_orig);


### PR DESCRIPTION
The override flag was not being tested in the smoke tests. This PR adds tests for setting explicitly to either a true or a false value.

Included in this pull request there is a commit that changes the tests using `ok()` into tests using `is()`. Since the tests were manually doing the check between expected and actual values, and since `Test::More` was already being `use`d, I thought this would be preferable.

This PR is part of the Pull Request Challenge.
