### PR TITLE
add travis to test the build CPR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: false
+language: perl
+
+perl:
+ #- "5.8"
+ #- "5.10"
+ #- "5.12"
+ #- "5.14"
+ - "5.16"
+ - "5.18"
+ - "5.20"
+ - "5.22"
+ - "5.24"
+
+install:
+  - dzil authordeps --missing | cpanm --notest|| { cat ~/.cpanm/build.log ; false ; }
+  - dzil listdeps --author --missing | cpanm --notest|| { cat ~/.cpanm/build.log ; false ; }
+
+script:
+  - git config user.email "jluis@cpan.org"
+  - git config user.name "jluis"
+  - dzil smoke
+


### PR DESCRIPTION
I was assigned this distribution on the April CPAN pull request challenge.

I created the  travis for myself to be able to work  systems where I don't have a proper developer environment but I can use Github to edit the files.

I'm plan to put at least a README on master stating the obvious that uses Dist::Zilla to build the distro and explain the extructure of the repository.

What do You think?