### PR TITLE
setenv_multi and unsetenv_multi added

### DIFF
--- a/C.xs
+++ b/C.xs
@@ -48,28 +48,8 @@
 # endif
 #endif
 
-MODULE = Env::C        PACKAGE = Env::C  PREFIX = env_c_
-
-char *
-env_c_getenv(key)
-    char *key
-
-    CODE:
-    RETVAL = getenv(key);
-
-    OUTPUT:
-    RETVAL
-
-MODULE = Env::C        PACKAGE = Env::C  PREFIX = env_c_
-
-int
-env_c_setenv(key, val, override=1)
-    char *key
-    char *val
-    int override;
-
-
-    CODE:
+inline int __setenv(const char *key, const char *val, int override) {
+    int RETVAL;
 #if !HAVE_SETENV
     if (override || getenv(key) == NULL) {
         char *old_env = getenv( key ); 
@@ -99,17 +79,11 @@ env_c_setenv(key, val, override=1)
 # endif
     RETVAL = setenv(key, val, override);
 #endif
+    return RETVAL;
+}
 
-    OUTPUT:
-    RETVAL
+inline void __unsetenv(const char *key) {
 
-MODULE = Env::C        PACKAGE = Env::C  PREFIX = env_c_
-
-void
-env_c_unsetenv(key)
-    char *key
-
-    PREINIT:
 #ifdef WIN32
     char *buff;
 #endif
@@ -119,7 +93,6 @@ env_c_unsetenv(key)
     char **envp;
 #endif
 
-    CODE:
 #ifdef WIN32
     buff = malloc(strlen(key) + 2);
     sprintf(buff, "%s=", key);
@@ -142,6 +115,42 @@ env_c_unsetenv(key)
     }
 #endif
 #endif
+}
+
+MODULE = Env::C        PACKAGE = Env::C  PREFIX = env_c_
+
+char *
+env_c_getenv(key)
+    char *key
+
+    CODE:
+    RETVAL = getenv(key);
+
+    OUTPUT:
+    RETVAL
+
+MODULE = Env::C        PACKAGE = Env::C  PREFIX = env_c_
+
+int
+env_c_setenv(key, val, override=1)
+    char *key
+    char *val
+    int override;
+
+    CODE:
+    RETVAL = __setenv(key, val, override);
+
+    OUTPUT:
+    RETVAL
+
+MODULE = Env::C        PACKAGE = Env::C  PREFIX = env_c_
+
+void
+env_c_unsetenv(key)
+    char *key
+
+    CODE:
+    __unsetenv(key);
 
 MODULE = Env::C        PACKAGE = Env::C  PREFIX = env_c_
 
@@ -165,6 +174,30 @@ env_c_getallenv()
 
     OUTPUT:
     RETVAL
+
+MODULE = Env::C        PACKAGE = Env::C  PREFIX = env_c_
+
+void
+env_c_setenv_multi(...)
+    PPCODE:
+    int i;
+    if (items % 3)
+        croak("Usage: setenv_multi(var1, value1, override1, var2, value2, override2, ...)");
+    for (i=0; i<items; i+=3)
+        __setenv(SvPV_nolen(ST(i)), SvPV_nolen(ST(i+1)), SvIV(ST(i+2)));
+    XSRETURN(0);
+
+
+MODULE = Env::C        PACKAGE = Env::C  PREFIX = env_c_
+
+void
+env_c_unsetenv_multi(...)
+    PPCODE:
+    int i;
+    for (i=0; i<items; i++)
+        __unsetenv(SvPV_nolen(ST(i)));
+    XSRETURN(0);
+
 
 MODULE = Env::C        PACKAGE = Env::C  PREFIX = env_c_
 

--- a/lib/Env/C.pm
+++ b/lib/Env/C.pm
@@ -41,10 +41,19 @@ version 0.14
   my $ar_env = Env::C::getallenv();
   print join "\n", @$ar_env;
 
+  Env::C::setenv_multi(
+      "VAR1", "value1", 1,
+      "VAR2", "value2", 0
+  );
+
+  Env::C::unsetenv_multi("VAR1", "VAR2");
+
 =head1 DESCRIPTION
 
 This module provides a Perl API for getenv(3), setenv(3) and
 unsetenv(3). It also can return all the C<environ> variables.
+You also can use C<setenv_multi> and C<getenv_multi> for bulk
+operations with environment.
 
 Sometimes Perl invokes modules with underlaying C APIs which rely on
 certain environment variables to be set. If these variables are set in
@@ -71,6 +80,14 @@ is not changed.
 
 The unsetenv() function deletes the variable C<$key> from the
 environment.
+
+=head2 setenv_multi($key1, $value1, [$override1], $key2, $value2, [$override2], ...)
+
+Similar to C<setenv>, but works with several variables at once.
+
+=head2 unsetenv_multi(@keys)
+
+Similar to C<unsetenv>, but works with several variables at once.
 
 =head2 getallenv()
 

--- a/t/smoke-multi.t
+++ b/t/smoke-multi.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+use Env::C;
+
+# we assume $ENV{USER} exists, but that might not be the case (e.g.: in
+# docker).  If not present, just use root.
+unless (exists $ENV{USER}) {
+    $ENV{USER} = 'root';
+}
+
+my $env1 = Env::C::getallenv();
+print "# ", scalar(@$env1), " env entries\n";
+#print join "\n", @$env;
+ok @$env1;
+
+Env::C::setenv_multi(
+    FOO  => foo  => 1,
+    BAR  => bar  => 0,
+    USER => toor => 0,
+);
+my $env2 = Env::C::getallenv();
+is_deeply [ sort(@$env1, 'FOO=foo', 'BAR=bar') ], [ sort @$env2 ], "setmulti 1";
+
+Env::C::setenv_multi(
+    FOO  => foo2 => 0,
+    BAR  => bar2 => 1,
+    USER => toor => 1,
+);
+my $env3 = Env::C::getallenv();
+is_deeply [ sort((grep { !/^USER=/ } @$env1), 'FOO=foo', 'BAR=bar2', 'USER=toor') ], [ sort @$env3 ], "setmulti 2";
+
+Env::C::unsetenv_multi(qw/FOO BAR/);
+my $env4 = Env::C::getallenv();
+is_deeply [ sort((grep { !/^USER=/ } @$env1), 'USER=toor') ], [ sort @$env4 ], "unsetmulti";


### PR DESCRIPTION
Hi Michael,
First of all, thank you for useful module. I want to suggest this patch with two XS functions added - setenv_multi and unsetenv_multi. For bulk operations setenv_multi works almost twice faster than combination of perl's loop and setenv.