### PR TITLE
Fix compiler warnings

### DIFF
--- a/C.xs
+++ b/C.xs
@@ -150,8 +150,6 @@ env_c_getallenv()
 
     PREINIT:
     int i = 0;
-    char *p;
-    AV *av = Nullav;
 #ifndef __BORLANDC__
     extern char **environ;
 #endif
@@ -159,7 +157,7 @@ env_c_getallenv()
     CODE:
     RETVAL = newAV();
 
-    while ((char*)environ[i] != '\0') {
+    while ((char*)environ[i] != NULL) {
         Perl_av_push(aTHX_ RETVAL, newSVpv((char*)environ[i++], 0));
     }
 


### PR DESCRIPTION
GCC 7.1.1 produces these warnings:

gcc -c   -D_REENTRANT -D_GNU_SOURCE -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -fwrapv -fno-strict-aliasing -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -g   -DVERSION=\"0.14\" -DXS_VERSION=\"0.14\" -fPIC "-I/usr/lib64/perl5/CORE"   C.c
C.xs: In function ‘XS_Env__C_getallenv’:
C.xs:162:30: warning: comparison between pointer and zero character constant [-Wpointer-compare]
     while ((char*)environ[i] != '\0') {
                              ^~
C.xs:162:12: note: did you mean to dereference the pointer?
     while ((char*)environ[i] != '\0') {
            ^
C.xs:154:9: warning: unused variable ‘av’ [-Wunused-variable]
     AV *av = Nullav;
         ^~
C.xs:153:11: warning: unused variable ‘p’ [-Wunused-variable]
     char *p;
           ^

This patch fixes it.